### PR TITLE
dbplyr 2.0.0 compatibility

### DIFF
--- a/tests/testthat/tests.R
+++ b/tests/testthat/tests.R
@@ -15,7 +15,7 @@ test_that("scidb works", {
       1
     )
   )
-  expect_length(dplyr::db_list_tables(x$con), 4)
+  expect_length(DBI::dbListTables(x$con), 4)
 })
 
 test_that("download functions work", {


### PR DESCRIPTION
dbplyr no longer implements the methods for generics that now live in DBI.